### PR TITLE
Add floor plan configuration UI

### DIFF
--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -13,6 +13,8 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.selector import (
     DeviceSelector,
     DeviceSelectorConfig,
+    FileSelector,
+    FileSelectorConfig,
     ObjectSelector,
     SelectOptionDict,
     SelectSelector,
@@ -27,11 +29,13 @@ from .const import (
     CONF_ATTENUATION,
     CONF_DEVICES,
     CONF_DEVTRACK_TIMEOUT,
+    CONF_FLOORPLAN_IMAGE,
     CONF_MAX_RADIUS,
     CONF_MAX_VELOCITY,
     CONF_REF_POWER,
     CONF_RSSI_OFFSETS,
     CONF_SAVE_AND_CLOSE,
+    CONF_SCANNER_COORDS,
     CONF_SCANNER_INFO,
     CONF_SCANNERS,
     CONF_SMOOTHING_SAMPLES,
@@ -190,6 +194,7 @@ class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
                 "selectdevices": "Select Devices",
                 "calibration1_global": "Calibration 1: Global",
                 "calibration2_scanners": "Calibration 2: Scanner RSSI Offsets",
+                "floorplan": "Floor Plan",
             },
             description_placeholders=messages,
         )
@@ -555,6 +560,28 @@ class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
             step_id="calibration2_scanners",
             data_schema=vol.Schema(data_schema),
             description_placeholders={"suffix": results_str},
+        )
+
+    async def async_step_floorplan(self, user_input=None):
+        """Configure the floor plan image and scanner coordinates."""
+        if user_input is not None:
+            self.options.update(user_input)
+            return await self._update_options()
+
+        data_schema = {
+            vol.Optional(
+                CONF_FLOORPLAN_IMAGE,
+                default=self.options.get(CONF_FLOORPLAN_IMAGE),
+            ): FileSelector(FileSelectorConfig(accept="image/*")),
+            vol.Optional(
+                CONF_SCANNER_COORDS,
+                default=self.options.get(CONF_SCANNER_COORDS, {}),
+            ): ObjectSelector(),
+        }
+
+        return self.async_show_form(
+            step_id="floorplan",
+            data_schema=vol.Schema(data_schema),
         )
 
     def _get_bermuda_device_from_registry(self, registry_id: str) -> BermudaDevice | None:

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -194,6 +194,12 @@ DOCS[CONF_SMOOTHING_SAMPLES] = (
     " make for slower distance increases. 10 or 20 seems good."
 )
 
+CONF_FLOORPLAN_IMAGE = "floorplan_image"
+DOCS[CONF_FLOORPLAN_IMAGE] = "Path to the uploaded floor plan image."
+
+CONF_SCANNER_COORDS = "scanner_coordinates"
+DOCS[CONF_SCANNER_COORDS] = "Scanner x/y coordinates on the floor plan."
+
 # Defaults
 DEFAULT_NAME = DOMAIN
 


### PR DESCRIPTION
## Summary
- add constants for floorplan image and scanner coordinates
- introduce new `floorplan` options flow step with FileSelector

## Testing
- `pre-commit run --files custom_components/bermuda/config_flow.py custom_components/bermuda/const.py custom_components/bermuda/translations/en.json custom_components/bermuda/translations/el.json custom_components/bermuda/translations/fr.json custom_components/bermuda/translations/nb.json custom_components/bermuda/translations/nl.json custom_components/bermuda/translations/pt.json`
- `./scripts/setup`
- `./scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_6855813211c483269574ffd601c4e1ef